### PR TITLE
Bugfix: implementation was rewritten with '-force=false'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ _testmain.go
 
 # Ignore generated .pb.go files in integration tests
 /integration/**/*.pb.*go
+# Unignore some files, used in tests
+!/integration/impl_exists/strings/strings.pb.impl.go
 
 # Ignore vendor, needed for better local development
 vendor/

--- a/cmd/protoc-gen-goclay/genhandler/handler.go
+++ b/cmd/protoc-gen-goclay/genhandler/handler.go
@@ -263,7 +263,7 @@ func annotateString(str string) string {
 }
 
 func fileExists(path string) bool {
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	dir, err := filepath.Abs(".")
 	if err != nil {
 		glog.V(-1).Info(err)
 	}

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -47,6 +47,7 @@ google.golang.org/grpc v1.13.0 h1:bHIbVsCwmvbArgCJmLdgOdHFXlKqTOVjbibbS19cXHc=
 google.golang.org/grpc v1.13.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/integration/impl_exists/Makefile
+++ b/integration/impl_exists/Makefile
@@ -1,0 +1,20 @@
+FIRST_GOPATH:=$(firstword $(subst :, ,$(GOPATH)))
+GRPC_GATEWAY_PATH?=${FIRST_GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway
+GEN_CLAY_BIN?=$(shell which protoc-gen-goclay)
+
+pwd:
+	@pwd
+
+clean:
+	find . -regex "\./pb/.*\.go" -exec rm {} +
+	rm -f main
+
+protoc:
+	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:. --go_out=plugins=grpc:. --goclay_out=force=false,impl=true,impl_path=../strings:. pb/strings.proto
+
+build:
+	go build -o main main.go
+	vgo build -o main main.go
+
+test: pwd clean protoc build
+	go test -v ./strings

--- a/integration/impl_exists/main.go
+++ b/integration/impl_exists/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/utrack/clay/integration/impl_standalone/strings"
+)
+
+func main() {
+	r := chi.NewMux()
+	desc := strings.NewStrings().GetDescription()
+	desc.RegisterHTTP(r)
+
+	r.Handle("/swagger.json", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write(desc.SwaggerDef())
+	}))
+
+	http.ListenAndServe(":8080", r)
+}

--- a/integration/impl_exists/pb/strings.proto
+++ b/integration/impl_exists/pb/strings.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+
+service Strings {
+    rpc ToUpper (String) returns (String) {
+        option (google.api.http) = {
+            get: "/strings/to_upper/{str}"
+        };
+    }
+}
+
+message String {
+    string str = 1;
+}

--- a/integration/impl_exists/strings/strings.pb.impl.go
+++ b/integration/impl_exists/strings/strings.pb.impl.go
@@ -1,0 +1,25 @@
+package strings
+
+import (
+	"context"
+	"strings"
+
+	desc "github.com/utrack/clay/integration/impl_exists/pb"
+	transport "github.com/utrack/clay/v2/transport"
+)
+
+type StringsImplementation struct{}
+
+func NewStrings() *StringsImplementation {
+	return &StringsImplementation{}
+}
+
+func (i *StringsImplementation) ToUpper(ctx context.Context, req *desc.String) (*desc.String, error) {
+	return &desc.String{Str: strings.ToUpper(req.Str)}, nil
+}
+
+// GetDescription is a simple alias to the ServiceDesc constructor.
+// It makes it possible to register the service implementation @ the server.
+func (i *StringsImplementation) GetDescription() transport.ServiceDesc {
+	return desc.NewStringsServiceDesc(i)
+}

--- a/integration/impl_exists/strings/strings_test.go
+++ b/integration/impl_exists/strings/strings_test.go
@@ -12,7 +12,7 @@ func TestImplementationExists(t *testing.T) {
 	impl := NewStrings()
 	res, err := impl.ToUpper(context.Background(), &desc.String{Str: "foo"})
 	if err != nil {
-		t.Fatalf("error is expected to be nil, got %q", err)
+		t.Fatalf("error is expected to be nil, got %q\n Implementation was re-generated!", err)
 	}
 	if res == nil || res.Str != "FOO" {
 		t.Fatalf("wrong result, got %v", res)

--- a/integration/impl_exists/strings/strings_test.go
+++ b/integration/impl_exists/strings/strings_test.go
@@ -1,0 +1,20 @@
+package strings
+
+import (
+	"context"
+	"testing"
+
+	desc "github.com/utrack/clay/integration/impl_exists/pb"
+)
+
+// TestImplementationExists tests if the implementation is not re-written after generation
+func TestImplementationExists(t *testing.T) {
+	impl := NewStrings()
+	res, err := impl.ToUpper(context.Background(), &desc.String{Str: "foo"})
+	if err != nil {
+		t.Fatalf("error is expected to be nil, got %q", err)
+	}
+	if res == nil || res.Str != "FOO" {
+		t.Fatalf("wrong result, got %v", res)
+	}
+}


### PR DESCRIPTION
Implementation was still rewritten with `--goclay_out=force=false,impl=true`.

It was OK if goclay was in $GOPATH, reproduced only when running `protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) ...`.

- Added tests
- fixed the bug