### PR TITLE
fix skiping fields in json response which have zero value

### DIFF
--- a/integration/json_emit_default_fields/Makefile
+++ b/integration/json_emit_default_fields/Makefile
@@ -1,0 +1,24 @@
+GOPATH?=$(HOME)/go
+FIRST_GOPATH:=$(firstword $(subst :, ,$(GOPATH)))
+GRPC_GATEWAY_PATH?=${FIRST_GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway
+GEN_CLAY_BIN?=$(shell which protoc-gen-goclay)
+GEN_GOFAST_BIN?=$(shell which protoc-gen-gofast)
+
+pwd:
+	@pwd
+
+clean:
+	rm -f ./pb/strings/strings.pb.go
+	rm -f ./pb/strings/strings.pb.goclay.go
+	rm -f ./strings/strings.pb.impl.go
+	rm -f main
+
+protoc:
+	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:. --gofast_out=plugins=grpc:. --goclay_out=impl=true,impl_path=../../strings:. pb/strings/strings.proto
+
+build:
+	go build -o main main.go
+	vgo build -o main main.go
+
+test: pwd clean protoc build
+	vgo test -v ./pb/strings

--- a/integration/json_emit_default_fields/main.go
+++ b/integration/json_emit_default_fields/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/utrack/clay/integration/http_headers_passthru/strings"
+)
+
+func main() {
+	r := chi.NewMux()
+	desc := strings.NewStrings().GetDescription()
+	desc.RegisterHTTP(r)
+
+	r.Handle("/swagger.json", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write(desc.SwaggerDef())
+	}))
+
+	http.ListenAndServe(":8080", r)
+}

--- a/integration/json_emit_default_fields/pb/strings/strings.proto
+++ b/integration/json_emit_default_fields/pb/strings/strings.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option go_package="pb/strings";
+
+import "google/api/annotations.proto";
+
+service Strings {
+    rpc ToLower (String) returns (String) {
+        option (google.api.http) = {
+            post: "/strings/to_lower"
+            body: "*"
+        };
+    }
+}
+
+message String {
+    string str = 1;
+}

--- a/integration/json_emit_default_fields/pb/strings/strings_test.go
+++ b/integration/json_emit_default_fields/pb/strings/strings_test.go
@@ -1,0 +1,84 @@
+package strings
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/utrack/clay/v2/transport"
+	"io/ioutil"
+)
+
+// assert type for the headers
+type a struct {
+	Name   string
+	Resp *String
+	MarshaledData string
+}
+
+// TestHTTPHeadersPass_vanillaHTTP tests that default HTTP middleware passes HTTP headers to
+// gRPC metadata.
+func TestHTTPHeadersPass_vanillaHTTP(t *testing.T) {
+	so := assert.New(t)
+	impl, ts := getTestSvc()
+	defer ts.Close()
+
+	tc := []a{
+		a{
+			Name:   "Empty string field",
+			Resp: &String{Str: ""},
+			MarshaledData: `{"str":""}`,
+		},
+	}
+
+
+
+
+	req, err := http.NewRequest("POST", ts.URL+pattern_goclay_Strings_ToLower_0_builder(), bytes.NewReader([]byte("{}")))
+	so.Nil(err)
+
+	for _, c := range tc {
+		impl.f = func(ctx context.Context, req *String) (*String, error) {
+			return c.Resp, nil
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		so.Nil(err)
+		data, err := ioutil.ReadAll(resp.Body)
+		so.Equal(c.MarshaledData, string(data))
+	}
+
+
+}
+
+
+func getTestSvc() (*StringsImplementation, *httptest.Server) {
+	mux := http.NewServeMux()
+	impl := NewStrings()
+	d := impl.GetDescription()
+	d.RegisterHTTP(mux)
+
+	ts := httptest.NewServer(mux)
+	return impl, ts
+}
+
+type StringsImplementation struct {
+	f func(ctx context.Context, req *String) (*String, error)
+}
+
+func NewStrings() *StringsImplementation {
+	return &StringsImplementation{}
+}
+
+func (i *StringsImplementation) ToLower(ctx context.Context, req *String) (*String, error) {
+	return i.f(ctx, req)
+}
+
+// GetDescription is a simple alias to the ServiceDesc constructor.
+// It makes it possible to register the service implementation @ the server.
+func (i *StringsImplementation) GetDescription() transport.ServiceDesc {
+	return NewStringsServiceDesc(i)
+}

--- a/transport/httpruntime/mjson.go
+++ b/transport/httpruntime/mjson.go
@@ -11,9 +11,9 @@ import (
 )
 
 var mpbjson = MarshalerPbJSON{
-	Marshaler:       &runtime.JSONPb{},
+	Marshaler:       &runtime.JSONPb{EmitDefaults: true,},
 	Unmarshaler:     &runtime.JSONPb{},
-	GogoMarshaler:   &gogojsonpb.Marshaler{},
+	GogoMarshaler:   &gogojsonpb.Marshaler{EmitDefaults: true,},
 	GogoUnmarshaler: &gogojsonpb.Unmarshaler{},
 }
 


### PR DESCRIPTION
After this changes default json marshaler won't skip fields with zero values in response body.

```
ts := &types.Timeslot{
    Start: 0,
    Duration: 2,
}
```
now we will response with:
```
{"start":0,"duration":2}
```
instead of
```
{"duration":2}
```
