### PR TITLE
Use kebab-case for service name folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,11 +44,16 @@ _testmain.go
 /integration/**/pb/strings.to_upper.go
 /integration/**/pb/strings.go
 /integration/**/strings/strings2.go
+/integration/**/strings/to_lower.go
+/integration/**/strings/to_upper.go
 /integration/**/strings/strings2.to_lower.go
 /integration/**/strings/strings2.to_upper.go
 /integration/**/strings2/strings2.go
 /integration/**/strings2/strings2.to_lower.go
 /integration/**/strings2/strings2.to_upper.go
+/integration/**/strings-api/strings_api.go
+/integration/**/strings-api/to_lower.go
+/integration/**/strings-api/to_upper.go
 /integration/snake_case_service/strings/strings_service.go
 /integration/snake_case_service/strings/strings_service.to_upper.go
 # Unignore some files, used in tests

--- a/cmd/protoc-gen-goclay/genhandler/handler.go
+++ b/cmd/protoc-gen-goclay/genhandler/handler.go
@@ -115,7 +115,7 @@ func (g *Generator) generateImpl(file *descriptor.File) (files []*plugin.CodeGen
 		if g.options.ServiceSubDir {
 			pkg, err = astPkg(descriptor.GoPackage{
 				Name: file.GoPkg.Name,
-				Path: filepath.Join(file.GoPkg.Path, g.options.ImplPath, internal.SnakeCase(svc.GetName())),
+				Path: filepath.Join(file.GoPkg.Path, g.options.ImplPath, internal.KebabCase(svc.GetName())),
 			})
 			if err != nil {
 				return nil, err
@@ -136,7 +136,7 @@ func (g *Generator) generateImplService(file *descriptor.File, svc *descriptor.S
 	if exists := astTypeExists(implTypeName(svc), astPkg); !exists || g.options.Force {
 		var output string
 		if g.options.ServiceSubDir {
-			output = fmt.Sprintf(filepath.Join(file.GoPkg.Path, g.options.ImplPath, internal.SnakeCase(svc.GetName()), "%s.go"), internal.SnakeCase(svc.GetName()))
+			output = fmt.Sprintf(filepath.Join(file.GoPkg.Path, g.options.ImplPath, internal.KebabCase(svc.GetName()), "%s.go"), internal.SnakeCase(svc.GetName()))
 		} else {
 			output = fmt.Sprintf(filepath.Join(file.GoPkg.Path, g.options.ImplPath, "%s.go"), internal.SnakeCase(svc.GetName()))
 		}
@@ -177,7 +177,7 @@ func (g *Generator) generateImplServiceMethod(file *descriptor.File, svc *descri
 	if exists := astMethodExists(implTypeName(svc), methodGoName, astPkg); !exists || g.options.Force {
 		var output string
 		if g.options.ServiceSubDir {
-			output = fmt.Sprintf(filepath.Join(file.GoPkg.Path, g.options.ImplPath, internal.SnakeCase(svc.GetName()), "%s.%s.go"), internal.SnakeCase(svc.GetName()), internal.SnakeCase(methodGoName))
+			output = fmt.Sprintf(filepath.Join(file.GoPkg.Path, g.options.ImplPath, internal.KebabCase(svc.GetName()), "%s.go"), internal.SnakeCase(methodGoName))
 		} else {
 			output = fmt.Sprintf(filepath.Join(file.GoPkg.Path, g.options.ImplPath, "%s.%s.go"), internal.SnakeCase(svc.GetName()), internal.SnakeCase(methodGoName))
 		}

--- a/cmd/protoc-gen-goclay/internal/kebab.go
+++ b/cmd/protoc-gen-goclay/internal/kebab.go
@@ -1,0 +1,9 @@
+package internal
+
+import (
+	"strings"
+)
+
+func KebabCase(s string) string {
+	return strings.Trim(strings.Replace(SnakeCase(s), "_", "-", -1), "-")
+}

--- a/cmd/protoc-gen-goclay/internal/kebab_test.go
+++ b/cmd/protoc-gen-goclay/internal/kebab_test.go
@@ -1,0 +1,77 @@
+package internal
+
+import (
+	"testing"
+)
+
+type KebabTest struct {
+	input  string
+	output string
+}
+
+var kebabTests = []KebabTest{
+	{"a", "a"},
+	{"kebab", "kebab"},
+	{"A", "a"},
+	{"ID", "id"},
+	{"MOTD", "motd"},
+	{"Kebab", "kebab"},
+	{"KebabTest", "kebab-test"},
+	{"APIResponse", "api-response"},
+	{"KebabID", "kebab-id"},
+	{"Kebab_Id", "kebab-id"},
+	{"Kebab_ID", "kebab-id"},
+	{"KebabIDGoogle", "kebab-id-google"},
+	{"LinuxMOTD", "linux-motd"},
+	{"OMGWTFBBQ", "omgwtfbbq"},
+	{"omg_wtf_bbq", "omg-wtf-bbq"},
+	{"woof_woof", "woof-woof"},
+	{"_woof_woof", "woof-woof"},
+	{"woof_woof_", "woof-woof"},
+	{"WOOF", "woof"},
+	{"Woof", "woof"},
+	{"woof", "woof"},
+	{"woof0_woof1", "woof0-woof1"},
+	{"_woof0_woof1_2", "woof0-woof1-2"},
+	{"woof0_WOOF1_2", "woof0-woof1-2"},
+	{"WOOF0", "woof0"},
+	{"Woof1", "woof1"},
+	{"woof2", "woof2"},
+	{"woofWoof", "woof-woof"},
+	{"woofWOOF", "woof-woof"},
+	{"woof_WOOF", "woof-woof"},
+	{"Woof_WOOF", "woof-woof"},
+	{"WOOFWoofWoofWOOFWoofWoof", "woof-woof-woof-woof-woof-woof"},
+	{"WOOF_Woof_woof_WOOF_Woof_woof", "woof-woof-woof-woof-woof-woof"},
+	{"Woof_W", "woof-w"},
+	{"Woof_w", "woof-w"},
+	{"WoofW", "woof-w"},
+	{"Woof_W_", "woof-w"},
+	{"Woof_w_", "woof-w"},
+	{"WoofW_", "woof-w"},
+	{"WOOF_", "woof"},
+	{"W_Woof", "w-woof"},
+	{"w_Woof", "w-woof"},
+	{"WWoof", "w-woof"},
+	{"_W_Woof", "w-woof"},
+	{"_w_Woof", "w-woof"},
+	{"_WWoof", "w-woof"},
+	{"_WOOF", "woof"},
+	{"_woof", "woof"},
+}
+
+func TestKebabCase(t *testing.T) {
+	for _, test := range kebabTests {
+		if KebabCase(test.input) != test.output {
+			t.Errorf("KebabCase(%q) -> %q, want %q", test.input, KebabCase(test.input), test.output)
+		}
+	}
+}
+
+func BenchmarkKebabCase(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, test := range kebabTests {
+			KebabCase(test.input)
+		}
+	}
+}

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-openapi/spec v0.0.0-20180415031709-bcff419492ee
 	github.com/gogo/protobuf v1.0.0
 	github.com/golang/protobuf v1.2.0
-	github.com/googleapis/googleapis v0.0.0-20181112190823-5e7316da92db // indirect
+	github.com/googleapis/googleapis v0.0.0-20181128001915-58249308b9c7 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.5.0
 	github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e
 	github.com/pkg/errors v0.8.0

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -24,14 +24,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/googleapis/googleapis v0.0.0-20181005165555-8f1de3d40e28 h1:sWQisCilqKMbezUudDb8K0tpMRboi7TGa0mV5Lzkk1w=
 github.com/googleapis/googleapis v0.0.0-20181005165555-8f1de3d40e28/go.mod h1:XrPm4xpez/lHHyE+8/G+NqQRcB4lg42HF9zQVTvxtXw=
-github.com/googleapis/googleapis v0.0.0-20181108015141-8027f17420d5 h1:xTOrlbeRzjnRd2T+StTBr1VjWFkEAB2pjuVEQ/4uWeY=
-github.com/googleapis/googleapis v0.0.0-20181108015141-8027f17420d5/go.mod h1:XrPm4xpez/lHHyE+8/G+NqQRcB4lg42HF9zQVTvxtXw=
-github.com/googleapis/googleapis v0.0.0-20181108185704-188ad84deb9e h1:E8k34sibWmXaIASl6exOvt5i898IpZt71s4T4F59xxE=
-github.com/googleapis/googleapis v0.0.0-20181108185704-188ad84deb9e/go.mod h1:XrPm4xpez/lHHyE+8/G+NqQRcB4lg42HF9zQVTvxtXw=
-github.com/googleapis/googleapis v0.0.0-20181110013721-8eaf18920599 h1:VppqDZfyEiOSQwu9ykJU8G4h7Kkmgo7titGriUeUfqM=
-github.com/googleapis/googleapis v0.0.0-20181110013721-8eaf18920599/go.mod h1:XrPm4xpez/lHHyE+8/G+NqQRcB4lg42HF9zQVTvxtXw=
-github.com/googleapis/googleapis v0.0.0-20181112190823-5e7316da92db h1:teDRAGZODWpy+tWgj+3O8tCfDiif5yrXrkrm/1CcbLc=
-github.com/googleapis/googleapis v0.0.0-20181112190823-5e7316da92db/go.mod h1:XrPm4xpez/lHHyE+8/G+NqQRcB4lg42HF9zQVTvxtXw=
+github.com/googleapis/googleapis v0.0.0-20181128001915-58249308b9c7 h1:9mOIZY/jDS7eNxH7lJkIBomxVbTrafNedHQmjc8uHaM=
+github.com/googleapis/googleapis v0.0.0-20181128001915-58249308b9c7/go.mod h1:XrPm4xpez/lHHyE+8/G+NqQRcB4lg42HF9zQVTvxtXw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0 h1:WcmKMm43DR7RdtlkEXQJyo5ws8iTp98CyhCCbOHMvNI=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
@@ -50,7 +44,6 @@ github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjM
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/utrack/clay v1.0.2 h1:CR0e4ZWGfkK5/XiMI6HgTMKjKc+dOhOu0tRC0G5CGtA=
 golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180629035331-4cb1c02c05b0 h1:eOjEPieBzQ+rKOvQTqwbkm/0BdWz2JQwUzaa97tcZ8k=
 golang.org/x/net v0.0.0-20180629035331-4cb1c02c05b0/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/integration/impl_service_sub_dir/Makefile
+++ b/integration/impl_service_sub_dir/Makefile
@@ -7,7 +7,7 @@ clean:
 	rm -f ./pb/strings.pb.go
 	rm -f ./pb/strings.pb.goclay.go
 	rm -f ./strings/strings.go
-	rm -f ./strings/strings.to_upper.go
+	rm -f ./strings/to_upper.go
 	rm -f main
 
 protoc: protoc-build

--- a/integration/impl_service_sub_dir_2/Makefile
+++ b/integration/impl_service_sub_dir_2/Makefile
@@ -6,19 +6,19 @@ pwd:
 clean:
 	rm -f ./pb/strings/strings.pb.go
 	rm -f ./pb/strings/strings.pb.goclay.go
-	rm -f ./pb/strings2/strings2.pb.go
-	rm -f ./pb/strings2/strings2.pb.goclay.go
+	rm -f ./pb/strings-api/strings_api.pb.go
+	rm -f ./pb/strings-api/strings_api.pb.goclay.go
 	rm -f ./strings/strings.go
-	rm -f ./strings/strings.to_lower.go
-	rm -f ./strings/strings.to_upper.go
-	rm -f ./strings2/strings2.go
-	rm -f ./strings2/strings2.to_lower.go
-	rm -f ./strings2/strings2.to_upper.go
+	rm -f ./strings/to_lower.go
+	rm -f ./strings/to_upper.go
+	rm -f ./strings-api/strings_api.go
+	rm -f ./strings-api/to_lower.go
+	rm -f ./strings-api/to_upper.go
 	rm -f main
 
 protoc: protoc-build
 	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:. --gofast_out=plugins=grpc:. --goclay_out=impl_type_name_tmpl=Server,impl_service_sub_dir=true,impl=true,impl_path=../..:. pb/strings/strings.proto
-	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:. --gofast_out=plugins=grpc:. --goclay_out=impl_type_name_tmpl=Server,impl_service_sub_dir=true,impl=true,impl_path=../..:. pb/strings2/strings2.proto
+	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:. --gofast_out=plugins=grpc:. --goclay_out=impl_type_name_tmpl=Server,impl_service_sub_dir=true,impl=true,impl_path=../..:. pb/strings-api/strings_api.proto
 
 build:
 	go build -o main main.go

--- a/integration/impl_service_sub_dir_2/main.go
+++ b/integration/impl_service_sub_dir_2/main.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/utrack/clay/integration/impl_service_sub_dir_2/strings"
-	"github.com/utrack/clay/integration/impl_service_sub_dir_2/strings2"
+	"github.com/utrack/clay/integration/impl_service_sub_dir_2/strings-api"
 )
 
 func main() {
 	r := chi.NewMux()
 	desc := strings.NewStrings().GetDescription()
 	desc.RegisterHTTP(r)
-	desc2 := strings2.NewStrings2().GetDescription()
+	desc2 := strings_api.NewStringsAPI().GetDescription()
 	desc2.RegisterHTTP(r)
 
 	r.Handle("/swagger.json", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/integration/impl_service_sub_dir_2/pb/strings-api/strings_api.proto
+++ b/integration/impl_service_sub_dir_2/pb/strings-api/strings_api.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "google/api/annotations.proto";
 
-service Strings2 {
+service StringsAPI {
     rpc ToUpper (String) returns (String) {
         option (google.api.http) = {
             get: "/strings2/to_upper/{str}"


### PR DESCRIPTION
* use `kebab-case` for service name folder
* change default name for method implementation files to `method_name.go` instead of `service_name.method_name.go` in case of `impl_service_sub_dir` is `true`