### PR TITLE
removing handler error wrapper

### DIFF
--- a/cmd/protoc-gen-goclay/genhandler/tpl_servicedesc.go
+++ b/cmd/protoc-gen-goclay/genhandler/tpl_servicedesc.go
@@ -77,7 +77,7 @@ func (d *{{ $svc.GetName | goTypeName }}Desc) RegisterHTTP(mux {{ pkg "transport
               {{ pkg "httpruntime" }}SetError(r.Context(),r,w,{{ pkg "errors" }}Wrap(err.Err,"couldn't parse request"))
               return
             }
-            {{ pkg "httpruntime" }}SetError(r.Context(),r,w,{{ pkg "errors" }}Wrap(err,"returned from handler"))
+            {{ pkg "httpruntime" }}SetError(r.Context(),r,w,err)
             return
         }
 

--- a/doc/example/pb/sum.pb.goclay.go
+++ b/doc/example/pb/sum.pb.goclay.go
@@ -112,7 +112,7 @@ func (d *SummatorDesc) RegisterHTTP(mux transport.Router) {
 					httpruntime.SetError(r.Context(), r, w, errors.Wrap(err.Err, "couldn't parse request"))
 					return
 				}
-				httpruntime.SetError(r.Context(), r, w, errors.Wrap(err, "returned from handler"))
+				httpruntime.SetError(r.Context(), r, w, err)
 				return
 			}
 


### PR DESCRIPTION
It's a very annoying thing when we return errors to the frontend.