### PR TITLE
Remove vgo crutches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,9 @@ env:
 before_install:
   - ./install-protobuf.sh
   - PATH=/home/travis/bin:$PATH protoc --version
-  # accomodate forks
-  - test ! -d $GOPATH/src/github.com/utrack/clay && mkdir -p $GOPATH/src/github.com/utrack; mv $TRAVIS_BUILD_DIR $_ || true
 
 script:
-  - PATH=/home/travis/bin:$GOPATH/bin:$PATH make integration
+  - GO111MODULE=on PATH=/home/travis/bin:$GOPATH/bin:$PATH make integration
 
 language: go
 

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,3 @@
-FIRST_GOPATH:=$(firstword $(subst :, ,$(GOPATH)))
-GOBIN:=$(FIRST_GOPATH)/bin
-
-VGO_PATH:=$(FIRST_GOPATH)/src/golang.org/x/vgo
-VGO_VERSION:=master
-VGO_BIN:=$(GOBIN)/vgo
-
-# install vgo
-$(VGO_BIN):
-ifeq (${VGO_VERSION},master)
-	$(info #Installing vgo version $(VGO_VERSION)...)
-ifneq ($(wildcard $(VGO_PATH)),)
-	rm -rf $(VGO_PATH)
-endif
-	go get -u golang.org/x/vgo
-
-else
-	$(info #Installing vgo version $(VGO_VERSION)...)
-ifeq ($(wildcard $(VGO_PATH)),)
-	mkdir -p $(VGO_PATH) && cd $(VGO_PATH) ;\
-	git clone https://github.com/golang/vgo.git .
-endif
-	cd $(VGO_PATH) && git fetch --tags && git checkout $(VGO_VERSION) ;\
-	git reset --hard && git clean -fd ;\
-	go build -o=$(VGO_BIN) main.go
-endif
-
-.PHONY: install
-install: $(VGO_BIN)
-	vgo mod vendor
-
 .PHONY: integration
-integration: install
+integration:
 	$(MAKE) -C ./integration test

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,6 @@ github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
-github.com/c2fo/testify v0.0.0-20150827203832-fba96363964a h1:lXGVReN5qeiyu6AZpIgYJN1PoXSy1koT3nUP3ZRMWm0=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -2,8 +2,9 @@ all: test
 
 include env.mk
 
-SUBDIRS := $(wildcard */.)
-SUBDIRS := $(filter-out bin/., $(SUBDIRS))
+SUBDIRS := $(wildcard */)
+SUBDIRS := $(dir $(SUBDIRS))
+SUBDIRS := $(filter-out bin/, $(SUBDIRS))
 SUBCLEAN = $(addsuffix .clean,$(SUBDIRS))
 
 

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,28 +1,20 @@
+all: test
+
 include env.mk
 
-all: clean protoc-build test
+SUBDIRS := $(wildcard */.)
+SUBDIRS := $(filter-out bin/., $(SUBDIRS))
+SUBCLEAN = $(addsuffix .clean,$(SUBDIRS))
 
-test:
-	@ \
-	success=0; \
-	failure=0; \
-	for i in `find */ -type f -name Makefile -not -path "*vendor/*"`; do \
-		cd $${i%/*}; \
-		if make -C . test; then \
-			success=$$((success+1)); \
-		else \
-			failure=$$((failure+1)); \
-			echo "${RED}TEST FAILED${NC}"; \
-		fi; \
-		cd ..; \
-		echo; \
-	done; \
-	echo "== RESULTS =="; \
-	echo "${GREEN}$$success TEST PASSED${NC}"; \
-	if [ "$$failure" -gt "0" ]; then \
-		echo "${RED}$$failure TEST FAILED${NC}"; \
-		exit 1; \
-	fi
 
-clean:
-	@find */ -type f -name Makefile -execdir sh -c "make clean; echo ;" \;
+test: protoc-build $(SUBDIRS)
+clean: $(SUBCLEAN)
+
+
+.PHONY: $(SUBDIRS)
+$(SUBDIRS):
+	cd $@ && $(MAKE) -C . test
+
+.PHONY: $(SUBCLEAN)
+$(SUBCLEAN): %.clean:
+	cd $* && $(MAKE) -C . clean

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -3,7 +3,6 @@ all: test
 include env.mk
 
 SUBDIRS := $(wildcard */)
-SUBDIRS := $(dir $(SUBDIRS))
 SUBDIRS := $(filter-out bin/, $(SUBDIRS))
 SUBCLEAN = $(addsuffix .clean,$(SUBDIRS))
 

--- a/integration/additional_bindings/Makefile
+++ b/integration/additional_bindings/Makefile
@@ -15,7 +15,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
 
 test: pwd clean protoc build
-	vgo test ./...
+	go test ./...

--- a/integration/binding_with_body_and_response/Makefile
+++ b/integration/binding_with_body_and_response/Makefile
@@ -1,8 +1,8 @@
 include ../env.mk
 
-$(shell vgo get github.com/googleapis/googleapis)
-GOOGLEAPIS_PKG:=$(shell vgo list -m all | grep github.com/googleapis/googleapis | awk '{print ($$4 != "" ? $$4 : $$1)}')
-GOOGLEAPIS_VERSION:=$(shell vgo list -m all | grep github.com/googleapis/googleapis | awk '{print ($$5 != "" ? $$5 : $$2)}')
+$(shell go get github.com/googleapis/googleapis)
+GOOGLEAPIS_PKG:=$(shell go list -m all | grep github.com/googleapis/googleapis | awk '{print ($$4 != "" ? $$4 : $$1)}')
+GOOGLEAPIS_VERSION:=$(shell go list -m all | grep github.com/googleapis/googleapis | awk '{print ($$5 != "" ? $$5 : $$2)}')
 GOOGLEAPIS_PATH:=${FIRST_GOPATH}/pkg/mod/${GOOGLEAPIS_PKG}@${GOOGLEAPIS_VERSION}
 
 pwd:
@@ -21,4 +21,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test -v .
+	go test -v .

--- a/integration/binding_with_body_and_response/Makefile
+++ b/integration/binding_with_body_and_response/Makefile
@@ -18,7 +18,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test -v .

--- a/integration/binding_with_different_types/Makefile
+++ b/integration/binding_with_different_types/Makefile
@@ -17,4 +17,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test -v .
+	go test -v .

--- a/integration/binding_with_different_types/Makefile
+++ b/integration/binding_with_different_types/Makefile
@@ -14,7 +14,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test -v .

--- a/integration/binding_with_different_types_post/Makefile
+++ b/integration/binding_with_different_types_post/Makefile
@@ -17,7 +17,7 @@ protoc: protoc-build
 	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:${GOGO_PATH}:. --gofast_out=goproto_registration=true,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,plugins=grpc:. --goclay_out=impl=true,impl_path=../strings:. pb/strings.proto
 
 build:
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test -v .

--- a/integration/binding_with_different_types_post/Makefile
+++ b/integration/binding_with_different_types_post/Makefile
@@ -1,7 +1,7 @@
 include ../env.mk
 
-GOGO_PKG:=$(shell vgo list -m all | grep github.com/gogo/protobuf | awk '{print ($$4 != "" ? $$4 : $$1)}')
-GOGO_VERSION:=$(shell vgo list -m all | grep github.com/gogo/protobuf | awk '{print ($$5 != "" ? $$5 : $$2)}')
+GOGO_PKG:=$(shell go list -m all | grep github.com/gogo/protobuf | awk '{print ($$4 != "" ? $$4 : $$1)}')
+GOGO_VERSION:=$(shell go list -m all | grep github.com/gogo/protobuf | awk '{print ($$5 != "" ? $$5 : $$2)}')
 GOGO_PATH:=${FIRST_GOPATH}/pkg/mod/${GOGO_PKG}@${GOGO_VERSION}
 
 pwd:
@@ -20,4 +20,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test -v .
+	go test -v .

--- a/integration/binding_with_repeated_field/Makefile
+++ b/integration/binding_with_repeated_field/Makefile
@@ -19,7 +19,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test -v .

--- a/integration/binding_with_repeated_field/Makefile
+++ b/integration/binding_with_repeated_field/Makefile
@@ -1,8 +1,8 @@
 include ../env.mk
 
-$(shell vgo get github.com/googleapis/googleapis)
-GOOGLEAPIS_PKG:=$(shell vgo list -m all | grep github.com/googleapis/googleapis | awk '{print ($$4 != "" ? $$4 : $$1)}')
-GOOGLEAPIS_VERSION:=$(shell vgo list -m all | grep github.com/googleapis/googleapis | awk '{print ($$5 != "" ? $$5 : $$2)}')
+$(shell go get github.com/googleapis/googleapis)
+GOOGLEAPIS_PKG:=$(shell go list -m all | grep github.com/googleapis/googleapis | awk '{print ($$4 != "" ? $$4 : $$1)}')
+GOOGLEAPIS_VERSION:=$(shell go list -m all | grep github.com/googleapis/googleapis | awk '{print ($$5 != "" ? $$5 : $$2)}')
 GOOGLEAPIS_PATH:=${FIRST_GOPATH}/pkg/mod/${GOOGLEAPIS_PKG}@${GOOGLEAPIS_VERSION}
 
 pwd:
@@ -22,4 +22,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test -v .
+	go test -v .

--- a/integration/client_cancel_request/Makefile
+++ b/integration/client_cancel_request/Makefile
@@ -17,4 +17,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test -v .
+	go test -v .

--- a/integration/client_cancel_request/Makefile
+++ b/integration/client_cancel_request/Makefile
@@ -14,7 +14,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test -v .

--- a/integration/env.mk
+++ b/integration/env.mk
@@ -14,8 +14,8 @@ export GEN_GOFAST_BIN
 GEN_GOGOFAST_BIN:=$(DIR)/bin/protoc-gen-gogofast
 export GEN_GOGOFAST_BIN
 
-GRPC_GATEWAY_PKG:=$(shell vgo list -m all | grep github.com/grpc-ecosystem/grpc-gateway | awk '{print ($$4 != "" ? $$4 : $$1)}')
-GRPC_GATEWAY_VERSION:=$(shell vgo list -m all | grep github.com/grpc-ecosystem/grpc-gateway | awk '{print ($$5 != "" ? $$5 : $$2)}')
+GRPC_GATEWAY_PKG:=$(shell go list -m all | grep github.com/grpc-ecosystem/grpc-gateway | awk '{print ($$4 != "" ? $$4 : $$1)}')
+GRPC_GATEWAY_VERSION:=$(shell go list -m all | grep github.com/grpc-ecosystem/grpc-gateway | awk '{print ($$5 != "" ? $$5 : $$2)}')
 GRPC_GATEWAY_PATH:=${FIRST_GOPATH}/pkg/mod/${GRPC_GATEWAY_PKG}@${GRPC_GATEWAY_VERSION}
 export GRPC_GATEWAY_PATH
 
@@ -25,7 +25,7 @@ NC=:\033[0m
 
 protoc-build:
 	$(info #Installing binary dependencies...)
-	GOBIN=$(LOCAL_BIN) vgo install github.com/utrack/clay/v2/cmd/protoc-gen-goclay
-	GOBIN=$(LOCAL_BIN) vgo install github.com/golang/protobuf/protoc-gen-go
-	GOBIN=$(LOCAL_BIN) vgo install github.com/gogo/protobuf/protoc-gen-gofast
-	GOBIN=$(LOCAL_BIN) vgo install github.com/gogo/protobuf/protoc-gen-gogofast
+	GOBIN=$(LOCAL_BIN) go install github.com/utrack/clay/v2/cmd/protoc-gen-goclay
+	GOBIN=$(LOCAL_BIN) go install github.com/golang/protobuf/protoc-gen-go
+	GOBIN=$(LOCAL_BIN) go install github.com/gogo/protobuf/protoc-gen-gofast
+	GOBIN=$(LOCAL_BIN) go install github.com/gogo/protobuf/protoc-gen-gogofast

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-openapi/spec v0.0.0-20180415031709-bcff419492ee
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.3.2
+	github.com/googleapis/googleapis v0.0.0-20200115224547-0735b4b09687 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.12.1
 	github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e
 	github.com/pkg/errors v0.8.1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -34,6 +34,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/googleapis/googleapis v0.0.0-20200115224547-0735b4b09687 h1:+F2mdNvzHf2x95m0NNYCqFVY2jIFlur9IhFoE/bKR7I=
+github.com/googleapis/googleapis v0.0.0-20200115224547-0735b4b09687/go.mod h1:XrPm4xpez/lHHyE+8/G+NqQRcB4lg42HF9zQVTvxtXw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 h1:THDBEeQ9xZ8JEaCLyLQqXMMdRqNr0QAUJTIkQAUtFjg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=
 github.com/grpc-ecosystem/grpc-gateway v1.12.1 h1:zCy2xE9ablevUOrUZc3Dl72Dt+ya2FNAvC2yLYMHzi4=
@@ -67,6 +69,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/utrack/clay v1.0.2 h1:CR0e4ZWGfkK5/XiMI6HgTMKjKc+dOhOu0tRC0G5CGtA=
 github.com/y0ssar1an/q v1.0.7 h1:s3ckTY+wjk6Y0sFce4rIS1Ezf8S6d0UFJrKwe40MyiQ=
 github.com/y0ssar1an/q v1.0.7/go.mod h1:Q1Rk1StqWjSOfA/CF4zJEW1fLmkl5Cy8EsILdkB+DgE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/integration/go_package/Makefile
+++ b/integration/go_package/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/go_package_alias/Makefile
+++ b/integration/go_package_alias/Makefile
@@ -16,6 +16,5 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
 
 test: pwd clean protoc build

--- a/integration/go_package_alias_proto_in_root/Makefile
+++ b/integration/go_package_alias_proto_in_root/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/go_package_alias_proto_standalone/Makefile
+++ b/integration/go_package_alias_proto_standalone/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/go_package_proto_in_root/Makefile
+++ b/integration/go_package_proto_in_root/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/go_package_proto_standalone/Makefile
+++ b/integration/go_package_proto_standalone/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/go_package_with_alias/Makefile
+++ b/integration/go_package_with_alias/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/go_package_with_alias_proto_in_root/Makefile
+++ b/integration/go_package_with_alias_proto_in_root/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/go_package_with_alias_proto_standalone/Makefile
+++ b/integration/go_package_with_alias_proto_standalone/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/gogo_enums/Makefile
+++ b/integration/gogo_enums/Makefile
@@ -15,7 +15,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test ./pb/strings

--- a/integration/gogo_enums/Makefile
+++ b/integration/gogo_enums/Makefile
@@ -18,4 +18,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test ./pb/strings
+	go test ./pb/strings

--- a/integration/google_empty/Makefile
+++ b/integration/google_empty/Makefile
@@ -31,6 +31,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/grpc_gateway_1_4_1/Makefile
+++ b/integration/grpc_gateway_1_4_1/Makefile
@@ -19,6 +19,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/grpc_gateway_1_4_1/go.sum
+++ b/integration/grpc_gateway_1_4_1/go.sum
@@ -71,6 +71,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/utrack/clay v1.0.2 h1:CR0e4ZWGfkK5/XiMI6HgTMKjKc+dOhOu0tRC0G5CGtA=
+github.com/utrack/clay/integration v0.0.0-20200115122418-23099905ef49 h1:Bvv99I9V9lqKdV1gGud5F5Qw4fd5tQfQNfiKPoARYoQ=
 github.com/y0ssar1an/q v1.0.7/go.mod h1:Q1Rk1StqWjSOfA/CF4zJEW1fLmkl5Cy8EsILdkB+DgE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=

--- a/integration/http_headers_passthru/Makefile
+++ b/integration/http_headers_passthru/Makefile
@@ -15,7 +15,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test -v ./pb/strings

--- a/integration/http_headers_passthru/Makefile
+++ b/integration/http_headers_passthru/Makefile
@@ -18,4 +18,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test -v ./pb/strings
+	go test -v ./pb/strings

--- a/integration/http_headers_response/Makefile
+++ b/integration/http_headers_response/Makefile
@@ -15,7 +15,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test -v ./pb/strings

--- a/integration/http_headers_response/Makefile
+++ b/integration/http_headers_response/Makefile
@@ -18,4 +18,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test -v ./pb/strings
+	go test -v ./pb/strings

--- a/integration/impl_exists/Makefile
+++ b/integration/impl_exists/Makefile
@@ -16,4 +16,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test -v ./strings
+	go test -v ./strings

--- a/integration/impl_exists/Makefile
+++ b/integration/impl_exists/Makefile
@@ -13,7 +13,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test -v ./strings

--- a/integration/impl_file_name_tmpl/Makefile
+++ b/integration/impl_file_name_tmpl/Makefile
@@ -13,7 +13,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	go test -v ./strings

--- a/integration/impl_service_sub_dir/Makefile
+++ b/integration/impl_service_sub_dir/Makefile
@@ -15,7 +15,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test -v ./strings

--- a/integration/impl_service_sub_dir/Makefile
+++ b/integration/impl_service_sub_dir/Makefile
@@ -18,4 +18,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test -v ./strings
+	go test -v ./strings

--- a/integration/impl_service_sub_dir_2/Makefile
+++ b/integration/impl_service_sub_dir_2/Makefile
@@ -22,6 +22,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/impl_standalone/Makefile
+++ b/integration/impl_standalone/Makefile
@@ -16,6 +16,5 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
 
 test: pwd clean protoc build

--- a/integration/impl_standalone_without_swagger/Makefile
+++ b/integration/impl_standalone_without_swagger/Makefile
@@ -15,7 +15,6 @@ protoc: protoc-build
 	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:. --gofast_out=plugins=grpc:. --goclay_out=swagger=false,impl=true,impl_path=../strings:. pb/strings.proto
 
 build:
-	go build -o main main.go
-	vgo build -o main .
+	go build -o main .
 
 test: pwd clean protoc build

--- a/integration/impl_type_name_tmpl/Makefile
+++ b/integration/impl_type_name_tmpl/Makefile
@@ -16,4 +16,4 @@ build:
 	
 
 test: pwd clean protoc build
-	vgo test -v ./strings
+	go test -v ./strings

--- a/integration/impl_type_name_tmpl/Makefile
+++ b/integration/impl_type_name_tmpl/Makefile
@@ -13,7 +13,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+	
 
 test: pwd clean protoc build
 	vgo test -v ./strings

--- a/integration/imported_type_in_request/Makefile
+++ b/integration/imported_type_in_request/Makefile
@@ -18,6 +18,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/imported_type_in_response/Makefile
+++ b/integration/imported_type_in_response/Makefile
@@ -18,6 +18,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/no_bindings/Makefile
+++ b/integration/no_bindings/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/one_location/Makefile
+++ b/integration/one_location/Makefile
@@ -15,7 +15,6 @@ protoc: protoc-build
 	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:. --gofast_out=plugins=grpc:. --goclay_out=impl=true:. pb/strings.proto
 
 build:
-	go build -o main main.go
-	vgo build -o main .
+	go build -o main .
 
 test: pwd clean protoc build

--- a/integration/one_location_with_dot_package/Makefile
+++ b/integration/one_location_with_dot_package/Makefile
@@ -16,6 +16,5 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
 
 test: pwd clean protoc build

--- a/integration/one_location_with_go_package_alias/Makefile
+++ b/integration/one_location_with_go_package_alias/Makefile
@@ -15,7 +15,6 @@ protoc: protoc-build
 	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:. --gofast_out=plugins=grpc:. --goclay_out=impl=true:. pb/strings.proto
 
 build:
-	go build -o main main.go
-	vgo build -o main .
+	go build -o main .
 
 test: pwd clean protoc build

--- a/integration/one_location_with_package/Makefile
+++ b/integration/one_location_with_package/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/panic_in_response_marshaler/Makefile
+++ b/integration/panic_in_response_marshaler/Makefile
@@ -1,7 +1,7 @@
 include ../env.mk
 
-GOGO_PKG:=$(shell vgo list -m all | grep github.com/gogo/protobuf | awk '{print ($$4 != "" ? $$4 : $$1)}')
-GOGO_VERSION:=$(shell vgo list -m all | grep github.com/gogo/protobuf | awk '{print ($$5 != "" ? $$5 : $$2)}')
+GOGO_PKG:=$(shell go list -m all | grep github.com/gogo/protobuf | awk '{print ($$4 != "" ? $$4 : $$1)}')
+GOGO_VERSION:=$(shell go list -m all | grep github.com/gogo/protobuf | awk '{print ($$5 != "" ? $$5 : $$2)}')
 GOGO_PATH:=${FIRST_GOPATH}/pkg/mod/${GOGO_PKG}@${GOGO_VERSION}
 
 pwd:
@@ -20,4 +20,4 @@ build:
 	
 
 test: pwd clean protoc build
-	vgo test -v .
+	go test -v .

--- a/integration/panic_in_response_marshaler/Makefile
+++ b/integration/panic_in_response_marshaler/Makefile
@@ -17,7 +17,7 @@ protoc: protoc-build
 	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:${GOGO_PATH}:. --gofast_out=goproto_registration=true,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,plugins=grpc:. --goclay_out=impl=true,impl_path=../strings:. pb/strings.proto
 
 build:
-	vgo build -o main .
+	
 
 test: pwd clean protoc build
 	vgo test -v .

--- a/integration/partial_bindings/Makefile
+++ b/integration/partial_bindings/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/proto_in_root/Makefile
+++ b/integration/proto_in_root/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/proto_standalone/Makefile
+++ b/integration/proto_standalone/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/proto_two_services/Makefile
+++ b/integration/proto_two_services/Makefile
@@ -19,6 +19,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build

--- a/integration/response_vs_response_body/Makefile
+++ b/integration/response_vs_response_body/Makefile
@@ -1,7 +1,7 @@
 include ../env.mk
 
-GOGO_PKG:=$(shell vgo list -m all | grep github.com/gogo/protobuf | awk '{print ($$4 != "" ? $$4 : $$1)}')
-GOGO_VERSION:=$(shell vgo list -m all | grep github.com/gogo/protobuf | awk '{print ($$5 != "" ? $$5 : $$2)}')
+GOGO_PKG:=$(shell go list -m all | grep github.com/gogo/protobuf | awk '{print ($$4 != "" ? $$4 : $$1)}')
+GOGO_VERSION:=$(shell go list -m all | grep github.com/gogo/protobuf | awk '{print ($$5 != "" ? $$5 : $$2)}')
 GOGO_PATH:=${FIRST_GOPATH}/pkg/mod/${GOGO_PKG}@${GOGO_VERSION}
 
 pwd:
@@ -20,4 +20,4 @@ build:
 	
 
 test: pwd clean protoc build
-	vgo test -v .
+	go test -v .

--- a/integration/response_vs_response_body/Makefile
+++ b/integration/response_vs_response_body/Makefile
@@ -17,7 +17,7 @@ protoc: protoc-build
 	protoc --plugin=protoc-gen-goclay=$(GEN_CLAY_BIN) --plugin=protoc-gen-gofast=$(GEN_GOFAST_BIN) -I/usr/local/include:${GRPC_GATEWAY_PATH}/third_party/googleapis:${GOGO_PATH}:. --gofast_out=goproto_registration=true,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,plugins=grpc:. --goclay_out=impl=true,impl_path=../strings:. pb/strings.proto
 
 build:
-	vgo build -o main .
+	
 
 test: pwd clean protoc build
 	vgo test -v .

--- a/integration/snake_case_message/Makefile
+++ b/integration/snake_case_message/Makefile
@@ -15,6 +15,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+	
 
 test: pwd clean protoc build

--- a/integration/snake_case_method/Makefile
+++ b/integration/snake_case_method/Makefile
@@ -16,6 +16,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+	
 
 test: pwd clean protoc build

--- a/integration/snake_case_service/Makefile
+++ b/integration/snake_case_service/Makefile
@@ -15,6 +15,6 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+	
 
 test: pwd clean protoc build

--- a/integration/swagger_comments/Makefile
+++ b/integration/swagger_comments/Makefile
@@ -16,4 +16,4 @@ protoc: protoc-build
 build:
 
 test: pwd clean protoc build
-	vgo test ./pb/strings
+	go test ./pb/strings

--- a/integration/swagger_def_sam_json_case/Makefile
+++ b/integration/swagger_def_sam_json_case/Makefile
@@ -19,4 +19,4 @@ build:
 
 
 test: pwd clean protoc build
-	vgo test ./pb/strings
+	go test ./pb/strings

--- a/integration/swagger_def_sam_json_case/Makefile
+++ b/integration/swagger_def_sam_json_case/Makefile
@@ -16,7 +16,7 @@ protoc: protoc-build
 
 build:
 	go build -o main main.go
-	vgo build -o main .
+
 
 test: pwd clean protoc build
 	vgo test ./pb/strings

--- a/integration/swagger_default_options/Makefile
+++ b/integration/swagger_default_options/Makefile
@@ -16,4 +16,4 @@ protoc: protoc-build
 build:
 
 test: pwd clean protoc build
-	vgo test ./pb/strings
+	go test ./pb/strings


### PR DESCRIPTION
There's a lot of vgo-related code; it's not needed anymore since Go 1.10 EOL'd.