### PR TITLE
swagger: add flag to add title

### DIFF
--- a/cmd/protoc-gen-goclay/main.go
+++ b/cmd/protoc-gen-goclay/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/utrack/clay/v3/cmd/protoc-gen-goclay/third-party/grpc-gateway/internals/codegenerator"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/utrack/clay/v3/cmd/protoc-gen-goclay/third-party/grpc-gateway/internals/codegenerator"
 
 	"github.com/golang/glog"
 	"github.com/utrack/clay/v3/cmd/protoc-gen-goclay/genhandler"
@@ -23,6 +24,7 @@ var (
 	grpcAPIConfiguration = flag.String("grpc_api_configuration", "", "path to gRPC API Configuration in YAML format")
 	withImpl             = flag.Bool("impl", false, "generate simple implementations for proto Services. Implementation will not be generated if it already exists. See also `force` option")
 	withSwagger          = flag.Bool("swagger", true, "generate swagger.json")
+	withSwaggerTitle     = flag.String("swagger_title", "", "title to be used for the swagger being generated")
 	withSwaggerPath      = flag.String("swagger_path", "", "in addition to swagger in pb.goclay.go, generate separate swagger file at provided path")
 	applyHTTPMiddlewares = flag.Bool("http_middlewares", true, "apply default HTTP millewares")
 	implPath             = flag.String("impl_path", "", "path where the implementation is generated (for impl = true)")
@@ -110,7 +112,7 @@ func main() {
 	}
 
 	if *withSwagger {
-		swagBuf, err := genSwaggerDef(reg, req)
+		swagBuf, err := genSwaggerDef(reg, req, *withSwaggerTitle)
 		if err != nil {
 			emitError(err)
 			return

--- a/cmd/protoc-gen-goclay/swagger.go
+++ b/cmd/protoc-gen-goclay/swagger.go
@@ -7,8 +7,8 @@ import (
 	plugin "google.golang.org/protobuf/types/pluginpb"
 )
 
-func genSwaggerDef(reg *descriptor.Registry, req *plugin.CodeGeneratorRequest) (map[string][]byte, error) {
-	gsw := genopenapi.New(reg)
+func genSwaggerDef(reg *descriptor.Registry, req *plugin.CodeGeneratorRequest, swaggerTitle string) (map[string][]byte, error) {
+	gsw := genopenapi.New(reg, swaggerTitle)
 	var targets []*descriptor.File
 	for _, target := range req.FileToGenerate {
 		f, err := reg.LookupFile(target)

--- a/cmd/protoc-gen-goclay/third-party/grpc-gateway/protoc-gen-openapiv2/internals/genopenapi/generator.go
+++ b/cmd/protoc-gen-goclay/third-party/grpc-gateway/protoc-gen-openapiv2/internals/genopenapi/generator.go
@@ -28,7 +28,8 @@ var (
 )
 
 type generator struct {
-	reg *descriptor.Registry
+	reg   *descriptor.Registry
+	title string
 }
 
 type wrapper struct {
@@ -42,8 +43,8 @@ type GeneratorOptions struct {
 }
 
 // New returns a new generator which generates grpc gateway files.
-func New(reg *descriptor.Registry) gen.Generator {
-	return &generator{reg: reg}
+func New(reg *descriptor.Registry, title string) gen.Generator {
+	return &generator{reg: reg, title: title}
 }
 
 // Merge a lot of OpenAPI file (wrapper) to single one OpenAPI file
@@ -191,7 +192,7 @@ func (g *generator) Generate(targets []*descriptor.File) ([]*descriptor.Response
 	var openapis []*wrapper
 	for _, file := range targets {
 		glog.V(1).Infof("Processing %s", file.GetName())
-		swagger, err := applyTemplate(param{File: file, reg: g.reg})
+		swagger, err := applyTemplate(param{File: file, reg: g.reg, title: g.title})
 		if err == errNoTargetService {
 			glog.V(1).Infof("%s: %v", file.GetName(), err)
 			continue

--- a/cmd/protoc-gen-goclay/third-party/grpc-gateway/protoc-gen-openapiv2/internals/genopenapi/template.go
+++ b/cmd/protoc-gen-goclay/third-party/grpc-gateway/protoc-gen-openapiv2/internals/genopenapi/template.go
@@ -1277,6 +1277,11 @@ func renderServices(services []*descriptor.Service, paths openapiPathsObject, re
 
 // This function is called with a param which contains the entire definition of a method.
 func applyTemplate(p param) (*openapiSwaggerObject, error) {
+	title := *p.Name
+	if p.title != "" {
+		title = p.title
+	}
+
 	// Create the basic template object. This is the object that everything is
 	// defined off of.
 	s := openapiSwaggerObject{
@@ -1287,7 +1292,7 @@ func applyTemplate(p param) (*openapiSwaggerObject, error) {
 		Paths:       make(openapiPathsObject),
 		Definitions: make(openapiDefinitionsObject),
 		Info: openapiInfoObject{
-			Title:   *p.File.Name,
+			Title:   title,
 			Version: "version not set",
 		},
 	}

--- a/cmd/protoc-gen-goclay/third-party/grpc-gateway/protoc-gen-openapiv2/internals/genopenapi/types.go
+++ b/cmd/protoc-gen-goclay/third-party/grpc-gateway/protoc-gen-openapiv2/internals/genopenapi/types.go
@@ -10,7 +10,8 @@ import (
 
 type param struct {
 	*descriptor.File
-	reg *descriptor.Registry
+	reg   *descriptor.Registry
+	title string
 }
 
 // http://swagger.io/specification/#infoObject


### PR DESCRIPTION
Currently the title of the generated swagger file is the name of the
file. This provides no user input to customize.

Let's add a new flag `-swagger_title` which will allow the user to
provide a title and this is propagated to the lower layers and used
during the swagger generation.

We still default to filename if no title is provided.

Signed-off-by: Karthik Nayak <karthik.188@gmail.com>