### PR TITLE
Makes httpmw.DefaultChain configurable to be more flexible

### DIFF
--- a/transport/httpruntime/httpmw/headers.go
+++ b/transport/httpruntime/httpmw/headers.go
@@ -12,7 +12,8 @@ import (
 )
 
 // DefaultChain is a chain that gets applied to the generated handlers.
-func DefaultChain(next http.HandlerFunc) http.HandlerFunc {
+// It is a singleton, so you can update it if you want and know what you are doing.
+var DefaultChain = func(next http.HandlerFunc) http.HandlerFunc {
 	return InjectTransportStream(
 		HeadersToGRPCMD(
 			next,


### PR DESCRIPTION
For now (as of github.com/grpc-ecosystem/grpc-gateway/v2@v2.10.2), PopulateQueryParameters is very strict about query params duplication.
And it does not allow urls like `/slug?param1=1&param1=1` as it has more than one value for the parameter that declared as a single value.
So, we would need to handle it before passing the url to  PopulateQueryParameters function.

The easiest way I see to do this is to update `httpmw.DefaultChain`, but I want to make it optional and configurable.
